### PR TITLE
label deconf

### DIFF
--- a/scripts/layer/core/Live.js
+++ b/scripts/layer/core/Live.js
@@ -5,6 +5,8 @@ const defaultTo = require('lodash/defaultTo');
 const isEmpty = require('lodash/isEmpty');
 const isFunction = require('lodash/isFunction');
 
+const $ = require('jquery');
+
 const TILE_ADD = Symbol();
 
 const REDRAW_TIMEOUT_MS = 800;
@@ -159,6 +161,44 @@ class Live extends lumo.Layer {
 
 	getParams() {
 		return this.params;
+	}
+
+	postUpdate() {
+		const $dc = $('.deconfliction-collider');
+		const tree = new lumo.RTree({
+				collisionType: lumo.RECTANGLE,
+				nodeCapacity: 32
+			});
+
+		$dc.sort(function(a,b){
+			const sizeA = $(a).outerHeight();
+			const sizeB = $(b).outerHeight();
+			if(sizeA < sizeB) {
+				return 1
+			}else if(sizeA > sizeB) {
+				return -1;
+			}
+			return 0;
+		});
+
+		$dc.each(function(index, element){
+			const $e = $(element);
+			const position = $e.offset();
+			const w = $e.width();
+			const h = $e.height();
+			const point = {
+				'minX': position.left,
+				'maxX': position.left + w,
+				'minY': position.top,
+				'maxY': position.top + h
+			}
+
+			if(tree.searchRectangle(point.minX, point.maxX, point.minY, point.maxY) !== null) {
+				$(element).css('visibility', 'hidden');
+			} else {
+				tree.insert([point]);
+			}
+		});
 	}
 }
 

--- a/scripts/layer/core/Live.js
+++ b/scripts/layer/core/Live.js
@@ -5,8 +5,6 @@ const defaultTo = require('lodash/defaultTo');
 const isEmpty = require('lodash/isEmpty');
 const isFunction = require('lodash/isFunction');
 
-const $ = require('jquery');
-
 const TILE_ADD = Symbol();
 
 const REDRAW_TIMEOUT_MS = 800;
@@ -161,44 +159,6 @@ class Live extends lumo.Layer {
 
 	getParams() {
 		return this.params;
-	}
-
-	postUpdate() {
-		const $dc = $('.deconfliction-collider');
-		const tree = new lumo.RTree({
-				collisionType: lumo.RECTANGLE,
-				nodeCapacity: 32
-			});
-
-		$dc.sort(function(a,b){
-			const sizeA = $(a).outerHeight();
-			const sizeB = $(b).outerHeight();
-			if(sizeA < sizeB) {
-				return 1
-			}else if(sizeA > sizeB) {
-				return -1;
-			}
-			return 0;
-		});
-
-		$dc.each(function(index, element){
-			const $e = $(element);
-			const position = $e.offset();
-			const w = $e.width();
-			const h = $e.height();
-			const point = {
-				'minX': position.left,
-				'maxX': position.left + w,
-				'minY': position.top,
-				'maxY': position.top + h
-			}
-
-			if(tree.searchRectangle(point.minX, point.maxX, point.minY, point.maxY) !== null) {
-				$(element).css('visibility', 'hidden');
-			} else {
-				tree.insert([point]);
-			}
-		});
 	}
 }
 

--- a/scripts/render/html/CommunityLabel.js
+++ b/scripts/render/html/CommunityLabel.js
@@ -29,6 +29,7 @@ class CommunityLabel extends lumo.HTMLRenderer {
 		this.labelMaxLength = defaultTo(options.labelMaxLength, 256);
 		this.labelThreshold = defaultTo(options.labelThreshold, 0.6);
 		this.labelField = defaultTo(options.labelField, 'metadata');
+		this.labelDeconflict = defaultTo(options.labelDeconflict, true);
 	}
 
 	onAdd(layer) {
@@ -42,6 +43,42 @@ class CommunityLabel extends lumo.HTMLRenderer {
 		this.click = event => {
 			this.onClick(event);
 		};
+		if (this.labelDeconflict) {
+			this.deconflict = () => {
+				const tree = new lumo.RTree({
+					collisionType: lumo.RECTANGLE,
+					nodeCapacity: 64
+				});
+				// grab all labels
+				const $labels = $(this.container).find('.community-label');
+				// sort based on size / importance
+				$labels.sort((a, b) => {
+					return b.offsetHeight - a.offsetHeight;
+				});
+				// check if they conflict, if so, hide them
+				$labels.each((index, element) => {
+					const position = $(element).offset();
+					const point = {
+						minX: position.left,
+						maxX: position.left + element.offsetWidth,
+						minY: position.top,
+						maxY: position.top + element.offsetHeight
+					};
+					const collision = tree.searchRectangle(
+						point.minX,
+						point.maxX,
+						point.minY,
+						point.maxY);
+					if (collision) {
+						element.style.visibility = 'hidden';
+					} else {
+						element.style.visibility = 'visible';
+						tree.insert([ point ]);
+					}
+				});
+			};
+			this.on(lumo.POST_DRAW, this.deconflict);
+		}
 		$(this.container).on('mouseover', this.mouseover);
 		$(this.container).on('mouseout', this.mouseout);
 		$(this.container).on('click', this.click);
@@ -51,6 +88,9 @@ class CommunityLabel extends lumo.HTMLRenderer {
 		$(this.container).off('mouseover', this.mouseover);
 		$(this.container).off('mouseout', this.mouseout);
 		$(this.container).off('click', this.click);
+		if (this.labelDeconflict) {
+			this.removeListener(lumo.POST_DRAW, this.deconflict);
+		}
 		this.mouseover = null;
 		this.mouseout = null;
 		this.click = null;
@@ -137,7 +177,7 @@ class CommunityLabel extends lumo.HTMLRenderer {
 			const y = points[index*2+1] - (height / 2);
 
 			const div = $(`
-				<div class="community-label deconfliction-collider" style="
+				<div class="community-label" style="
 					left: ${x}px;
 					bottom: ${y}px;
 					opacity: ${opacity};

--- a/scripts/render/html/CommunityLabel.js
+++ b/scripts/render/html/CommunityLabel.js
@@ -137,7 +137,7 @@ class CommunityLabel extends lumo.HTMLRenderer {
 			const y = points[index*2+1] - (height / 2);
 
 			const div = $(`
-				<div class="community-label" style="
+				<div class="community-label deconfliction-collider" style="
 					left: ${x}px;
 					bottom: ${y}px;
 					opacity: ${opacity};
@@ -147,6 +147,7 @@ class CommunityLabel extends lumo.HTMLRenderer {
 					font-size: ${fontSize}px;
 					line-height: ${fontSize}px;">${label}</div>
 				`);
+
 			div.data('community', community);
 			divs = divs.add(div);
 		});


### PR DESCRIPTION
Essentially pushes the very ugly for lumo jquery stuff out into the layer implementation.  I was thinking of adding postUpdate to base lumo.Layer class so we wouldn't need to check if it exists (i'm not married to the name).
I feel like having a "render done" hook for a DOM renderer is entirely reasonable paradigm which can be found in many libraries.