### PR TITLE
Add an option to limit the number of drill-downs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,13 @@
 
 An in-progress version being developed on the `master` branch.
 
+## 0.14.2 - Oct 17th, 2017
+### Added
+- `limitBounds` option to `veldt.Layer.Drilldown` and `veldt.Renderer.HTML.Drilldown` to allow a limit to be set on the number of bounds that can be added.
+
+### Fixed
+- Fix `veldt.Renderer.HTML.Drilldown` mouse event issue on Linux only.
+
 ## 0.14.1 - Oct 16th, 2017
 ### Added
 - `drilldowneditstart`, `drilldownedit`, and `drilldowneditend` events to `veldt.Renderer.HTML.Drilldown`.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "veldt",
-  "version": "0.14.1",
+  "version": "0.14.2",
   "author": "Kevin Birk <kbirk@uncharted.software>",
   "main": "scripts/exports.js",
   "style": "styles/**/*.css",

--- a/scripts/layer/core/Drilldown.js
+++ b/scripts/layer/core/Drilldown.js
@@ -1,6 +1,7 @@
 'use strict';
 
 const lumo = require('lumo');
+const defaultTo = require('lodash/defaultTo');
 
 const clipBounds = function(cell, bounds) {
 	const clipped = new Map();
@@ -24,9 +25,11 @@ class Drilldown extends lumo.Overlay {
 	 * Instantiates a drilldown layer.
 	 *
 	 * @param {Object} options - The options parameter.
+	 * @param {number} options.boundsLimit - The maximum number of bounds that can be added.
 	 */
 	constructor(options = {}) {
 		super(options);
+		this.boundsLimit = defaultTo(options.boundsLimit, null);
 		this.bounds = new Map();
 	}
 
@@ -53,6 +56,7 @@ class Drilldown extends lumo.Overlay {
 	 */
 	enableDrawing() {
 		if (this.plot) {
+			this.renderer.setBoundsLimit(this.boundsLimit);
 			this.renderer.enableDrawing();
 		}
 	}


### PR DESCRIPTION
This PR also fixes an issue with deleting drill-downs that occurs when running on Linux (Chrome and Chromium).