### PR TITLE
Swap canvas map

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@
 
 An in-progress version being developed on the `master` branch.
 
+## 0.14.9 - Jan 29th, 2018
+### Changed
+- Cache a map of cavanses at different resolutions instead of just a single copy.
+
 ## 0.14.7 - Jan 16th, 2018
 ### Changed
 - Bump dependencies.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "veldt",
-  "version": "0.14.8",
+  "version": "0.14.9",
   "author": "Kevin Birk <kbirk@uncharted.software>",
   "main": "scripts/exports.js",
   "style": "styles/**/*.css",

--- a/scripts/render/canvas/Heatmap.js
+++ b/scripts/render/canvas/Heatmap.js
@@ -6,7 +6,7 @@ const ColorRamp = require('../color/ColorRamp');
 const Transform = require('../transform/Transform');
 const CanvasRenderer = require('../dom/CanvasRenderer');
 
-let swapCanvas = null;
+let canvasMap = {};
 
 class Heatmap extends CanvasRenderer {
 
@@ -68,11 +68,14 @@ class Heatmap extends CanvasRenderer {
 	}
 
 	blitCanvas(canvas, bins, resolution, transform, extrema, range, colorRamp) {
-		if (!swapCanvas) {
-			swapCanvas = document.createElement('canvas');
-			swapCanvas.height = resolution;
-			swapCanvas.width = resolution;
+		if (!canvasMap[resolution]) {
+			canvas = document.createElement('canvas');
+			canvas.height = resolution;
+			canvas.width = resolution;
+			canvasMap[resolution] = canvas;
 		}
+
+		const swapCanvas = canvasMap[resolution];
 		const swapCtx = swapCanvas.getContext('2d');
 		const imageData = swapCtx.getImageData(0, 0, resolution, resolution);
 		const data = imageData.data;

--- a/scripts/render/canvas/Heatmap.js
+++ b/scripts/render/canvas/Heatmap.js
@@ -69,10 +69,10 @@ class Heatmap extends CanvasRenderer {
 
 	blitCanvas(canvas, bins, resolution, transform, extrema, range, colorRamp) {
 		if (!canvasMap[resolution]) {
-			canvas = document.createElement('canvas');
-			canvas.height = resolution;
-			canvas.width = resolution;
-			canvasMap[resolution] = canvas;
+			const swap = document.createElement('canvas');
+			swap.height = resolution;
+			swap.width = resolution;
+			canvasMap[resolution] = swap;
 		}
 
 		const swapCanvas = canvasMap[resolution];


### PR DESCRIPTION
Change swapCanvas to map so multiple canvas resolutions can be cached.