### PR TITLE
Expose lumo interfaces

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@
 
 An in-progress version being developed on the `master` branch.
 
+## 0.14.9 - Mar 20th, 2018
+### Changed
+- Expose lumo interface.
+
 ## 0.14.7 - Jan 16th, 2018
 ### Changed
 - Bump dependencies.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "veldt",
-  "version": "0.14.8",
+  "version": "0.14.9",
   "author": "Kevin Birk <kbirk@uncharted.software>",
   "main": "scripts/exports.js",
   "style": "styles/**/*.css",

--- a/scripts/exports.js
+++ b/scripts/exports.js
@@ -1,10 +1,13 @@
 'use strict';
 
+const lumo = require('lumo');
+
 module.exports = {
 	Map: require('./map/Map'),
 	Layer: require('./layer/exports'),
 	Renderer: require('./render/exports'),
 	Requestor: require('./request/Requestor'),
 	ColorRamp: require('./render/color/ColorRamp'),
-	Request: require('./layer/request/Request')
+	Request: require('./layer/request/Request'),
+	lumo: lumo
 };


### PR DESCRIPTION
We have a case where we want to have a single SVG overlay. There doesn't seem to be any thing within veldt that does this directly. 

Exposing lumo, specifically `lumo.Overlay` and `lumo.OverlayRenderer` enables us create this layer ourselves. 

As this is a somewhat special case, I am not sure if there are any benefits of incorporating the SVG overlay directly into veldt.